### PR TITLE
Language name fix

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -19,7 +19,7 @@
      <div class="languages">
       <nav>
         <ul>
-        <li><a href="?lang=es">Castellano</a></li>
+        <li><a href="?lang=es">Español</a></li>
         <li><a href="?lang=ca">Català</a></li>
         <li><a href="?lang=cs">Čeština</a></li>
         <li><a href="?lang=da">Dansk</a></li>


### PR DESCRIPTION
Although Castillian is also correct because it's a language born in Castilla (a region of Spain), the term Spanish is a better choice because this language is the language for more regions of Spain than Castilla, and also it's a language common for all Spain, even the regions that also have and use its own language. Moreover it is best know as Spanish both in Spain and outside Spain.